### PR TITLE
Allow the use of parameter and format string as per the standard syntax

### DIFF
--- a/FormatWith/FormatWith.csproj
+++ b/FormatWith/FormatWith.csproj
@@ -24,7 +24,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/crozone/FormatWith</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>Include XML documentation in package.</PackageReleaseNotes>
+    <PackageReleaseNotes>Key:format syntax now supported for FormatWith and FormattableWith</PackageReleaseNotes>
+    <Version>3.0.0</Version>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/FormatWith/Internal/FormatWithMethods.cs
+++ b/FormatWith/Internal/FormatWithMethods.cs
@@ -19,7 +19,7 @@ namespace FormatWith.Internal
         {
             return FormatWith(
                 formatString,
-                key => new ReplacementResult(replacements.TryGetValue(key, out string value), value),
+                (key, format) => new ReplacementResult(replacements.TryGetValue(key, out string value), value),
                 missingKeyBehaviour,
                 fallbackReplacementValue,
                 openBraceChar,
@@ -36,7 +36,7 @@ namespace FormatWith.Internal
         {
             return FormatWith(
                 formatString,
-                key => new ReplacementResult(replacements.TryGetValue(key, out object value), value),
+                (key, format) => new ReplacementResult(replacements.TryGetValue(key, out object value), value),
                 missingKeyBehaviour,
                 fallbackReplacementValue,
                 openBraceChar,
@@ -56,7 +56,7 @@ namespace FormatWith.Internal
             if (replacementObject == null) throw new ArgumentNullException(nameof(replacementObject));
 
             return FormatWith(formatString,
-                key => FromReplacementObject(key, replacementObject),
+                (key, format) => FromReplacementObject(key, replacementObject),
                 missingKeyBehaviour,
                 fallbackReplacementValue,
                 openBraceChar,
@@ -65,7 +65,7 @@ namespace FormatWith.Internal
 
         public static string FormatWith(
             string formatString,
-            Func<string, ReplacementResult> handler,
+            Func<string, string, ReplacementResult> handler,
             MissingKeyBehaviour missingKeyBehaviour = MissingKeyBehaviour.ThrowException,
             object fallbackReplacementValue = null,
             char openBraceChar = '{',

--- a/FormatWith/StringExtensions.cs
+++ b/FormatWith/StringExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using FormatWith.Internal;
-using System.Runtime.CompilerServices;
 using System.Collections;
 
 namespace FormatWith
@@ -147,7 +144,7 @@ namespace FormatWith
         /// <returns>The formatted string</returns>
         public static string FormatWith(
             this string formatString,
-            Func<string, ReplacementResult> handler)
+            Func<string, string, ReplacementResult> handler)
         {
             return FormatWithMethods.FormatWith(formatString, handler);
         }
@@ -165,7 +162,7 @@ namespace FormatWith
         /// <returns>The formatted string</returns>
         public static string FormatWith(
             this string formatString,
-            Func<string, ReplacementResult> handler,
+            Func<string, string, ReplacementResult> handler,
             MissingKeyBehaviour missingKeyBehaviour = MissingKeyBehaviour.ThrowException,
             object fallbackReplacementValue = null,
             char openBraceChar = '{',

--- a/FormatWithTests/FormatProvider/UpperCaseFormatProvider.cs
+++ b/FormatWithTests/FormatProvider/UpperCaseFormatProvider.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace FormatWithTests.FormatProvider
+{
+    internal class UpperCaseFormatProvider : IFormatProvider
+    {
+        private readonly UpperCaseFormatter _formatter;
+
+        public UpperCaseFormatProvider()
+        {
+            _formatter = new UpperCaseFormatter();
+        }
+
+        public object GetFormat(Type formatType)
+        {
+            if (formatType == typeof(ICustomFormatter))
+                return _formatter;
+
+            return null;
+        }
+ 
+        class UpperCaseFormatter : ICustomFormatter
+        {
+            public string Format(string format, object arg, IFormatProvider formatProvider)
+            {
+                if(arg == null) return string.Empty;
+
+                if (format == "upper" && arg is string str)
+                {
+                    return str.ToUpper();
+                }
+
+                return arg.ToString();
+            }
+        }
+    }
+}

--- a/FormatWithTests/FormatWithTests.cs
+++ b/FormatWithTests/FormatWithTests.cs
@@ -31,6 +31,13 @@ namespace FormatWithTests
         }
 
         [Fact]
+        public void TestParameterFormat()
+        {
+            string replacement = TestFormat7.FormatWith(new { Today = TestFormat7Date });
+            Assert.Equal(TestFormat7Solution, replacement);
+        }
+
+        [Fact]
         public void TestNestedPropertiesReplacements()
         {
             string replacement = TestFormat5.FormatWith(new { Foo = new { Replacement1 = Replacement1 } });
@@ -130,7 +137,7 @@ namespace FormatWithTests
         public void TestCustomHandler1()
         {
             string replacement = "Hey, {make this uppercase!} Thanks.".FormatWith(
-                (parameter) => new ReplacementResult(true, parameter.ToUpper())
+                (parameter, format) => new ReplacementResult(true, parameter.ToUpper())
                 );
 
             Assert.Equal("Hey, MAKE THIS UPPERCASE! Thanks.", replacement);
@@ -140,31 +147,19 @@ namespace FormatWithTests
         public void TestCustomHandler2()
         {
             string replacement = "<abcDEF123:reverse>, <abcDEF123:uppercase>, <abcDEF123:lowercase>.".FormatWith(
-                (parameter) =>
+                (parameter, format) =>
                 {
-                    int splitIndex = parameter.LastIndexOf(':');
-                    if (splitIndex < 0)
+                    switch (format)
                     {
-                        return new ReplacementResult(true, parameter);
+                        case "uppercase":
+                            return new ReplacementResult(true, parameter.ToUpper());
+                        case "lowercase":
+                            return new ReplacementResult(true, parameter.ToLower());
+                        case "reverse":
+                            return new ReplacementResult(true, new string(parameter.Reverse().ToArray()));
+                        default:
+                            return new ReplacementResult(false, parameter);
                     }
-                    else
-                    {
-                        string value = parameter.Substring(0, splitIndex);
-                        string modifier = parameter.Length > splitIndex + 1 ? parameter.Substring(splitIndex + 1) : string.Empty;
-
-                        switch (modifier)
-                        {
-                            case "uppercase":
-                                return new ReplacementResult(true, value.ToUpper());
-                            case "lowercase":
-                                return new ReplacementResult(true, value.ToLower());
-                            case "reverse":
-                                return new ReplacementResult(true, new string(value.Reverse().ToArray()));
-                            default:
-                                return new ReplacementResult(false, null);
-                        }
-                    }
-
                 },
                 MissingKeyBehaviour.ReplaceWithFallback,
                 "Fallback",

--- a/FormatWithTests/FormattableWithTests.cs
+++ b/FormatWithTests/FormattableWithTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Xunit;
 using FormatWith;
+using FormatWithTests.FormatProvider;
 using static FormatWithTests.TestStrings;
 
 namespace FormatWithTests
@@ -56,6 +56,19 @@ namespace FormatWithTests
             Assert.Equal(1, formattableString.ArgumentCount);
             Assert.Equal(Replacement1, formattableString.GetArgument(0));
             Assert.Equal(TestFormat5Solution, formattableString.ToString());
+        }
+
+        [Fact]
+        public void TestFormatString()
+        {
+            FormattableString formattableString = TestFormat6.FormattableWith(new { Replacement1 = Replacement1 });
+            Assert.Equal(TestFormat6Composite, formattableString.Format);
+            Assert.Equal(1, formattableString.ArgumentCount);
+            Assert.Equal(Replacement1, formattableString.GetArgument(0));
+
+            var upperCaseFormatProvider = new UpperCaseFormatProvider();
+            
+            Assert.Equal(TestFormat6Solution, formattableString.ToString(upperCaseFormatProvider));
         }
 
         [Fact]

--- a/FormatWithTests/TestStrings.cs
+++ b/FormatWithTests/TestStrings.cs
@@ -24,5 +24,14 @@ namespace FormatWithTests
         public static readonly string TestFormat5 = "abc{Foo.Replacement1}";
         public static readonly string TestFormat5Composite = "abc{0}";
         public static readonly string TestFormat5Solution = $"abc{Replacement1}";
+
+        public static readonly string TestFormat6 = "abc{Replacement1:upper}";
+        public static readonly string TestFormat6Composite = "abc{0:upper}";
+        public static readonly string TestFormat6Solution = $"abc{Replacement1.ToUpper()}";
+        
+        public static readonly string TestFormat7 = "Today is {Today:YYYYMMDD HH:mm}";
+        public static readonly string TestFormat7Composite = "Today is {0:YYYYMMDD HH:mm}";
+        public static readonly DateTime TestFormat7Date = new DateTime(2018, 10, 30, 17, 25, 0);
+        public static readonly string TestFormat7Solution = $"Today is {TestFormat7Date:YYYYMMDD HH:mm}";
     }
 }

--- a/README.md
+++ b/README.md
@@ -80,38 +80,26 @@ The first, second, and third overload of FormattableWith() function much the sam
 
 ### Handler overloads
 
-A custom handler can be passed to both FormatWith() and FormattableWith(). The handler is passed the value of each parameter key, and is responsible for providing a `ReplacementResult` in response. The `ReplacementResult` contains the `Value` which will be substituted, as well as a boolean `Success` parameter indicating whether the replacement was successful. If `Success` is false, the `MissingKeyBehaviour` is followed, as per the other overloads of FormatWith.
+A custom handler can be passed to both FormatWith() and FormattableWith(). The handler is passed the value of each parameter key and format (if applicable). It is responsible for providing a `ReplacementResult` in response. The `ReplacementResult` contains the `Value` which will be substituted, as well as a boolean `Success` parameter indicating whether the replacement was successful. If `Success` is false, the `MissingKeyBehaviour` is followed, as per the other overloads of FormatWith.
 
 This can allow for some neat tricks, and even complex behaviours.
 
 Example:
 
     "{abcDEF123:reverse}, {abcDEF123:uppercase}, {abcDEF123:lowercase}.".FormatWith(
-                (parameter) =>
+                (parameter, format) =>
                 {
-                    int splitIndex = parameter.LastIndexOf(':');
-                    if (splitIndex < 0)
+                    switch (format)
                     {
-                        return new ReplacementResult(true, parameter);
+                        case "uppercase":
+                            return new ReplacementResult(true, parameter.ToUpper());
+                        case "lowercase":
+                            return new ReplacementResult(true, parameter.ToLower());
+                        case "reverse":
+                            return new ReplacementResult(true, new string(parameter.Reverse().ToArray()));
+                        default:
+                            return new ReplacementResult(false, parameter);
                     }
-                    else
-                    {
-                        string value = parameter.Substring(0, splitIndex);
-                        string modifier = parameter.Length > splitIndex + 1 ? parameter.Substring(splitIndex + 1) : string.Empty;
-
-                        switch (modifier)
-                        {
-                            case "uppercase":
-                                return new ReplacementResult(true, value.ToUpper());
-                            case "lowercase":
-                                return new ReplacementResult(true, value.ToLower());
-                            case "reverse":
-                                return new ReplacementResult(true, new string(value.Reverse().ToArray()));
-                            default:
-                                return new ReplacementResult(false, null);
-                        }
-                    }
-
                 });
 
 Produces:


### PR DESCRIPTION
Split the parameter text by colon, allowing us to pass the parameter name and format string separately into the handle method for FormatWith.

FormattableWith remains the same, as the format part of the string is passed onto the FormattableString