### PR TITLE
Add Span-based implementation and netstandard2.1 target framework

### DIFF
--- a/FormatWith/FormatWith.csproj
+++ b/FormatWith/FormatWith.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<Title>FormatWith</Title>
 		<Product>FormatWith</Product>
 		<Description>String extension methods for performing {named} {{parameterized}} string formatting, written for NetStandard 2.0</Description>
@@ -40,5 +40,9 @@
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<DocumentationFile>bin\Release\netstandard2.0\FormatWith.xml</DocumentationFile>
 	</PropertyGroup>
+	
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<PackageReference Include="System.Memory" Version="4.5.4" />
+	</ItemGroup>
 
 </Project>

--- a/FormatWith/Internal/FormatHelpers.cs
+++ b/FormatWith/Internal/FormatHelpers.cs
@@ -12,353 +12,168 @@ namespace FormatWith.Internal
     internal static class FormatHelpers
     {
         /// <summary>
-        /// Processes a list of format tokens into a string
+        /// Processes a token into its resulting string.
         /// </summary>
-        /// <param name="tokens">List of tokens to turn into a string</param>
+        /// <param name="token">Current token to process</param>
+        /// <param name="resultBuilder">The StringBuilder which will contain the result</param>
         /// <param name="handler">The function used to perform the replacements on the format tokens</param>
         /// <param name="missingKeyBehaviour">The behaviour to use when the format string contains a parameter that is not present in the lookup dictionary</param>
         /// <param name="fallbackReplacementValue">When the <see cref="MissingKeyBehaviour.ReplaceWithFallback"/> is specified, this string is used as a fallback replacement value when the parameter is present in the lookup dictionary.</param>
-        /// <param name="outputLengthHint">Provides a hint to the underlying string builder to help reduce buffer reallocations.</param>
         /// <returns>The processed result of joining the tokens with the replacement dictionary.</returns>
-        public static string ProcessTokens(
-            IEnumerable<FormatToken> tokens,
+        public static void ProcessToken(
+            FormatToken token,
+            StringBuilder resultBuilder,
             Func<string, string, ReplacementResult> handler,
             MissingKeyBehaviour missingKeyBehaviour,
-            object fallbackReplacementValue,
-            int outputLengthHint)
+            object fallbackReplacementValue)
         {
-            // create a StringBuilder to hold the resultant output string
-            // use the input hint as the initial size
-            StringBuilder resultBuilder = new StringBuilder(outputLengthHint);
-
-            foreach (FormatToken thisToken in tokens)
+            if (token.TokenType == TokenType.Text)
             {
-                if (thisToken.TokenType == TokenType.Text)
-                {
-                    // token is a text token
-                    // add the token to the result string builder
-                    resultBuilder.Append(thisToken.SourceString, thisToken.StartIndex, thisToken.Length);
-                }
-                else if (thisToken.TokenType == TokenType.Parameter)
-                {
-                    // token is a parameter token
-                    // perform parameter logic now.
-                    var tokenKey = thisToken.Value;
-                    string format = null;
-                    var separatorIdx = tokenKey.IndexOf(":", StringComparison.Ordinal);
-                    if (separatorIdx > -1)
-                    {
-                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
-                        format = thisToken.Value.Substring(separatorIdx + 1);
-                    }
-
-                    // append the replacement for this parameter
-                    ReplacementResult replacementResult = handler(tokenKey, format);
-                
-                    if (replacementResult.Success)
-                    {
-                        // the key exists, add the replacement value
-                        // this does nothing if replacement value is null
-                        if (string.IsNullOrWhiteSpace(format))
-                        {
-                            resultBuilder.Append(replacementResult.Value);
-                        }
-                        else
-                        {
-                            resultBuilder.AppendFormat("{0:" + format + "}", replacementResult.Value);
-                        }
-                    }
-                    else
-                    {
-                        // the key does not exist, handle this using the missing key behaviour specified.
-                        switch (missingKeyBehaviour)
-                        {
-                            case MissingKeyBehaviour.ThrowException:
-                                // the key was not found as a possible replacement, throw exception
-                                throw new KeyNotFoundException($"The parameter \"{thisToken.Value}\" was not present in the lookup dictionary");
-                            case MissingKeyBehaviour.ReplaceWithFallback:
-                                resultBuilder.Append(fallbackReplacementValue);
-                                break;
-                            case MissingKeyBehaviour.Ignore:
-                                // the replacement value is the input key as a parameter.
-                                // use source string and start/length directly with append rather than
-                                // parameter.ParameterKey to avoid allocating an extra string
-                                resultBuilder.Append(thisToken.SourceString, thisToken.StartIndex, thisToken.Length);
-                                break;
-                        }
-                    }
-                }
+                // token is a text token
+                // add the token to the result string builder
+                resultBuilder.Append(token.Raw);
             }
-
-            // return the resultant string
-            return resultBuilder.ToString();
-        }
-
-        /// <summary>
-        /// Processes a list of format tokens into a string
-        /// </summary>
-        /// <param name="tokens">List of tokens to turn into a string</param>
-        /// <param name="handler">The function used to perform the replacements on the format tokens</param>
-        /// <param name="missingKeyBehaviour">The behaviour to use when the format string contains a parameter that is not present in the lookup dictionary</param>
-        /// <param name="fallbackReplacementValue">When the <see cref="MissingKeyBehaviour.ReplaceWithFallback"/> is specified, this string is used as a fallback replacement value when the parameter is present in the lookup dictionary.</param>
-        /// <param name="outputLengthHint"></param>
-        /// <returns>The processed result of joining the tokens with the replacement dictionary.</returns>
-        public static FormattableString ProcessTokensIntoFormattableString(
-            IEnumerable<FormatToken> tokens,
-            Func<string, ReplacementResult> handler,
-            MissingKeyBehaviour missingKeyBehaviour,
-            object fallbackReplacementValue,
-            int outputLengthHint)
-        {
-            List<object> replacementParams = new List<object>();
-
-            // create a StringBuilder to hold the resultant output string
-            // use the input hint as the initial size
-            StringBuilder resultBuilder = new StringBuilder(outputLengthHint);
-
-            // this is the index of the current placeholder in the composite format string
-            int placeholderIndex = 0;
-
-            foreach (FormatToken thisToken in tokens)
+            else if (token.TokenType == TokenType.Parameter)
             {
-                if (thisToken.TokenType == TokenType.Text)
+                // token is a parameter token
+                // perform parameter logic now.
+                // TODO: See about removing these ToString calls on tokenKey and format
+                string tokenKey = token.Value.ToString();
+                string format = null;
+                var separatorIdx = tokenKey.IndexOf(':');
+                if (separatorIdx > -1)
                 {
-                    // token is a text token.
-                    // add the token to the result string builder.
-                    // because this text is going into a standard composite format string,
-                    // any instaces of { or } must be escaped with {{ and }}
-                    resultBuilder.AppendWithEscapedBrackets(thisToken.SourceString, thisToken.StartIndex, thisToken.Length);
+                    tokenKey = token.Value.Slice(0, separatorIdx).ToString();
+                    format = token.Value.Slice(separatorIdx + 1).ToString();
                 }
-                else if (thisToken.TokenType == TokenType.Parameter)
+
+                // append the replacement for this parameter
+                ReplacementResult replacementResult = handler(tokenKey, format);
+
+                if (replacementResult.Success)
                 {
-                    // token is a parameter token
-                    // perform parameter logic now.
-                    var tokenKey = thisToken.Value;
-                    string format = null;
-                    var separatorIdx = tokenKey.IndexOf(":", StringComparison.Ordinal);
-                    if (separatorIdx > -1)
+                    // the key exists, add the replacement value
+                    // this does nothing if replacement value is null
+                    if (string.IsNullOrWhiteSpace(format))
                     {
-                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
-                        format = thisToken.Value.Substring(separatorIdx + 1);
-                    }
-
-                    // append the replacement for this parameter
-                    ReplacementResult replacementResult = handler(tokenKey);
-
-                    string IndexAndFormat()
-                    {
-                        if (string.IsNullOrWhiteSpace(format))
-                        {
-                            return "{" + placeholderIndex + "}";
-                        }
-
-                        return "{" + placeholderIndex + ":" + format + "}";
-                    }
-
-                    // append the replacement for this parameter
-                    if (replacementResult.Success)
-                    {
-                        // Instead of appending the replacement value directly as before,
-                        // append the next placeholder with the current placeholder index.
-                        // Add the actual replacement format item into the replacement values.
-                        resultBuilder.Append(IndexAndFormat());
-                        placeholderIndex++;
-                        replacementParams.Add(replacementResult.Value);
+                        resultBuilder.Append(replacementResult.Value);
                     }
                     else
                     {
-                        // the key does not exist, handle this using the missing key behaviour specified.
-                        switch (missingKeyBehaviour)
-                        {
-                            case MissingKeyBehaviour.ThrowException:
-                                // the key was not found as a possible replacement, throw exception
-                                throw new KeyNotFoundException($"The parameter \"{thisToken.Value}\" was not present in the lookup dictionary");
-                            case MissingKeyBehaviour.ReplaceWithFallback:
-                                // Instead of appending the replacement value directly as before,
-                                // append the next placeholder with the current placeholder index.
-                                // Add the actual replacement format item into the replacement values.
-                                resultBuilder.Append(IndexAndFormat());
-                                placeholderIndex++;
-                                replacementParams.Add(fallbackReplacementValue);
-                                break;
-                            case MissingKeyBehaviour.Ignore:
-                                resultBuilder.AppendWithEscapedBrackets(thisToken.SourceString, thisToken.StartIndex, thisToken.Length);
-                                break;
-                        }
-                    }
-                }
-            }
-
-            // return the resultant string
-            return FormattableStringFactory.Create(resultBuilder.ToString(), replacementParams.ToArray());
-        }
-
-        /// <summary>
-        /// Tokenizes a named format string into a list of text and parameter tokens for later processing.
-        /// </summary>
-        /// <param name="formatString">The format string, containing keys like {foo}</param>
-        /// <param name="openBraceChar">The character used to begin parameters</param>
-        /// <param name="closeBraceChar">The character used to end parameters</param>
-        /// <returns>A list of text and parameter tokens representing the input format string</returns>
-        public static IEnumerable<FormatToken> Tokenize(string formatString, char openBraceChar = '{', char closeBraceChar = '}')
-        {
-            if (formatString == null) throw new ArgumentNullException($"{nameof(formatString)} cannot be null.");
-
-            int currentTokenStart = 0;
-
-            // start the state machine!
-
-            bool insideBraces = false;
-
-            int index = 0;
-            while (index < formatString.Length)
-            {
-                if (!insideBraces)
-                {
-                    // currently not inside a pair of braces in the format string
-                    if (formatString[index] == openBraceChar)
-                    {
-                        // check if the brace is escaped
-                        if (index < formatString.Length - 1 && formatString[index + 1] == openBraceChar)
-                        {
-                            // ESCAPED OPEN BRACE
-
-                            // we have hit an escaped open brace
-                            // return current normal text, as well as the first brace
-                            // implemented as yield return, this generates a IEnumerator state machine.
-                            yield return new FormatToken(TokenType.Text, formatString, currentTokenStart, (index - currentTokenStart) + 1);
-
-                            // skip over braces
-                            index += 2;
-
-                            // set new current token start and current token length
-                            currentTokenStart = index;
-
-                            continue;
-                        }
-                        else
-                        {
-                            // START OF PARAMETER
-
-                            // not an escaped brace, set state to inside brace
-                            insideBraces = true;
-
-                            // we are leaving standard text and entering into a parameter
-                            // add the text traversed so far as a text token
-                            if (currentTokenStart < index)
-                            {
-                                yield return new FormatToken(TokenType.Text, formatString, currentTokenStart, (index - currentTokenStart));
-                            }
-
-                            // set the start index of the token to the start of this parameter
-                            currentTokenStart = index;
-
-                            index++;
-
-                            continue;
-                        }
-                    }
-                    else if (formatString[index] == closeBraceChar)
-                    {
-                        // handle case where closing brace is encountered outside braces
-                        if (index < formatString.Length - 1 && formatString[index + 1] == closeBraceChar)
-                        {
-                            // this is an escaped closing brace, this is okay
-
-                            // add the current normal text, as well as the first brace, to the
-                            // list of tokens as a text token.
-                            yield return new FormatToken(TokenType.Text, formatString, currentTokenStart, (index - currentTokenStart) + 1);
-
-                            // skip over braces
-                            index += 2;
-
-                            // set new current token start and current token length
-                            currentTokenStart = index;
-
-                            continue;
-                        }
-                        else
-                        {
-                            // this is an unescaped closing brace outside of braces.
-                            // throw a format exception
-                            throw new FormatException($"Unexpected closing brace at position {index}");
-                        }
-                    }
-                    else
-                    {
-                        // move onto next character
-                        index++;
-                        continue;
+                        resultBuilder.AppendFormat("{0:" + format + "}", replacementResult.Value);
                     }
                 }
                 else
                 {
-                    // currently inside a pair of braces in the format string
-                    if (formatString[index] == openBraceChar)
+                    // the key does not exist, handle this using the missing key behaviour specified.
+                    switch (missingKeyBehaviour)
                     {
-                        // found an opening brace
-                        // check if the brace is escaped
-                        if (index < formatString.Length - 1 && formatString[index + 1] == openBraceChar)
-                        {
-                            // there are escaped braces within the key
-                            // this is illegal, throw a format exception
-                            throw new FormatException($"Illegal escaped opening braces within a parameter at position {index}");
-                        }
-                        else
-                        {
-                            // not an escaped brace, we have an unexpected opening brace within a pair of braces
-                            throw new FormatException($"Unexpected opening brace inside a parameter at position {index}");
-                        }
+                        case MissingKeyBehaviour.ThrowException:
+                            // the key was not found as a possible replacement, throw exception
+                            throw new KeyNotFoundException(
+                                $"The parameter \"{token.Value.ToString()}\" was not present in the lookup dictionary");
+                        case MissingKeyBehaviour.ReplaceWithFallback:
+                            resultBuilder.Append(fallbackReplacementValue);
+                            break;
+                        case MissingKeyBehaviour.Ignore:
+                            // the replacement value is the input key as a parameter.
+                            // use source string and start/length directly with append rather than
+                            // parameter.ParameterKey to avoid allocating an extra string
+                            resultBuilder.Append(token.Raw);
+                            break;
                     }
-                    else if (formatString[index] == closeBraceChar)
-                    {
-                        // END OF PARAMETER
-                        // handle case where closing brace is encountered inside braces
-                        // don't attempt to check for escaped braces here - always assume the first brace closes the braces
-                        // since we cannot have escaped braces within parameters.
-
-                        // Add the parameter information to the parameter list
-                        yield return new FormatToken(TokenType.Parameter, formatString, currentTokenStart, (index - currentTokenStart) + 1);
-
-                        // set the state to be outside of any braces
-                        insideBraces = false;
-
-                        // jump over brace
-                        index++;
-
-                        // update current token start
-                        currentTokenStart = index;
-
-                        // jump to next state
-                        continue;
-                    } // if }
-                    else
-                    {
-                        // character has no special meaning, it is part of the current key
-                        // move onto next character
-                        index++;
-                        continue;
-                    } // else
-                } // if inside brace
-            } // while index < formatString.Length
-
-            // after the loop, if all braces were balanced, we should be outside all braces
-            // if we're not, the input string was misformatted.
-            if (insideBraces)
-            {
-                throw new FormatException($"The format string ended before the parameter was closed. Position {index}");
-            }
-            else
-            {
-                // outside braces. Add on any remaining text at the end of the format string
-                if (currentTokenStart < index)
-                {
-                    yield return new FormatToken(TokenType.Text, formatString, currentTokenStart, index - currentTokenStart);
                 }
             }
+        }
 
-            // finished tokenizing, so yield break to make MoveNext return false on the IEnumerator
-            yield break;
+        /// <summary>
+        /// Processes a list of format tokens into a string
+        /// </summary>
+        /// <param name="token">Current token to process</param>
+        /// <param name="resultBuilder">The StringBuilder which will contain the result</param>
+        /// <param name="replacementParams">Replacement parameters for the FormattableString.</param>
+        /// <param name="handler">The function used to perform the replacements on the format tokens</param>
+        /// <param name="missingKeyBehaviour">The behaviour to use when the format string contains a parameter that is not present in the lookup dictionary</param>
+        /// <param name="fallbackReplacementValue">When the <see cref="MissingKeyBehaviour.ReplaceWithFallback"/> is specified, this string is used as a fallback replacement value when the parameter is present in the lookup dictionary.</param>
+        /// <param name="placeholderIndex">The index of the current placeholder in the composite format string</param>
+        /// <returns>The processed result of joining the tokens with the replacement dictionary.</returns>
+        public static void ProcessTokenIntoFormattableString(
+            FormatToken token,
+            StringBuilder resultBuilder,
+            List<object> replacementParams,
+            Func<string, ReplacementResult> handler,
+            MissingKeyBehaviour missingKeyBehaviour,
+            object fallbackReplacementValue,
+            ref int placeholderIndex)
+        {
+            if (token.TokenType == TokenType.Text)
+            {
+                // token is a text token.
+                // add the token to the result string builder.
+                // because this text is going into a standard composite format string,
+                // any instaces of { or } must be escaped with {{ and }}
+                resultBuilder.AppendWithEscapedBrackets(token.SourceString, token.StartIndex, token.Length);
+            }
+            else if (token.TokenType == TokenType.Parameter)
+            {
+                // token is a parameter token
+                // perform parameter logic now.
+                // TODO: Look at removing the ToString on tokenKey/format.
+                var tokenKey = token.Value.ToString();
+                string format = null;
+                var separatorIdx = tokenKey.IndexOf(':');
+                if (separatorIdx > -1)
+                {
+                    tokenKey = token.Value.Slice(0, separatorIdx).ToString();
+                    format = token.Value.Slice(separatorIdx + 1).ToString();
+                }
+
+                // append the replacement for this parameter
+                ReplacementResult replacementResult = handler(tokenKey);
+
+                string IndexAndFormat(int index)
+                {
+                    if (string.IsNullOrWhiteSpace(format))
+                    {
+                        return "{" + index + "}";
+                    }
+
+                    return "{" + index + ":" + format + "}";
+                }
+
+                // append the replacement for this parameter
+                if (replacementResult.Success)
+                {
+                    // Instead of appending the replacement value directly as before,
+                    // append the next placeholder with the current placeholder index.
+                    // Add the actual replacement format item into the replacement values.
+                    resultBuilder.Append(IndexAndFormat(placeholderIndex));
+                    placeholderIndex++;
+                    replacementParams.Add(replacementResult.Value);
+                }
+                else
+                {
+                    // the key does not exist, handle this using the missing key behaviour specified.
+                    switch (missingKeyBehaviour)
+                    {
+                        case MissingKeyBehaviour.ThrowException:
+                            // the key was not found as a possible replacement, throw exception
+                            throw new KeyNotFoundException(
+                                $"The parameter \"{token.Value.ToString()}\" was not present in the lookup dictionary");
+                        case MissingKeyBehaviour.ReplaceWithFallback:
+                            // Instead of appending the replacement value directly as before,
+                            // append the next placeholder with the current placeholder index.
+                            // Add the actual replacement format item into the replacement values.
+                            resultBuilder.Append(IndexAndFormat(placeholderIndex));
+                            placeholderIndex++;
+                            replacementParams.Add(fallbackReplacementValue);
+                            break;
+                        case MissingKeyBehaviour.Ignore:
+                            resultBuilder.AppendWithEscapedBrackets(token.SourceString, token.StartIndex, token.Length);
+                            break;
+                    }
+                }
+            }
         }
     }
 }

--- a/FormatWith/Internal/FormatToken.cs
+++ b/FormatWith/Internal/FormatToken.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace FormatWith.Internal
 {
-    internal struct FormatToken
+    internal ref struct FormatToken
     {
-        public FormatToken(TokenType tokenType, string source, int startIndex, int length)
+        public FormatToken(TokenType tokenType, ReadOnlySpan<char> source, int startIndex, int length)
         {
             TokenType = tokenType;
             SourceString = source;
@@ -19,7 +19,7 @@ namespace FormatWith.Internal
         /// <summary>
         /// The source format string that the token exists within
         /// </summary>
-        public string SourceString { get; }
+        public ReadOnlySpan<char> SourceString { get; }
 
         /// <summary>
         /// The index of the start of the whole token, relative to the start of the source format string.
@@ -35,26 +35,20 @@ namespace FormatWith.Internal
         /// Gets the complete value.
         /// This performs a substring operation and allocates a new string object.
         /// </summary>
-        public string Raw {
-            get {
-                return SourceString.Substring(StartIndex, Length);
-            }
-        }
+        public ReadOnlySpan<char> Raw => SourceString.Slice(StartIndex, Length);
 
         /// <summary>
         /// Gets the token inner text.
         /// This performs a substring operation and allocates a new string object.
         /// </summary>
-        public string Value {
+        public ReadOnlySpan<char> Value {
             get {
                 if (TokenType == TokenType.Parameter)
                 {
-                    return SourceString.Substring(StartIndex + 1, Length - 2);
+                    return SourceString.Slice(StartIndex + 1, Length - 2);
                 }
-                else
-                {
-                    return SourceString.Substring(StartIndex, Length);
-                }
+
+                return SourceString.Slice(StartIndex, Length);
             }
         }
     }

--- a/FormatWith/Internal/StringBuilderExtensions.cs
+++ b/FormatWith/Internal/StringBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace FormatWith.Internal
     {
         public static void AppendWithEscapedBrackets(
                 this StringBuilder stringBuilder,
-                string value,
+                ReadOnlySpan<char> value,
                 int startIndex,
                 int count,
                 char openBraceChar = '{',
@@ -19,20 +19,36 @@ namespace FormatWith.Internal
             {
                 if (value[i] == openBraceChar)
                 {
-                    stringBuilder.Append(value, currentTokenStart, i - currentTokenStart);
+                    stringBuilder.Append(value.Slice(currentTokenStart, i - currentTokenStart));
                     stringBuilder.Append(openBraceChar);
                     currentTokenStart = i;
                 }
                 else if (value[i] == closeBraceChar)
                 {
-                    stringBuilder.Append(value, currentTokenStart, i - currentTokenStart);
+                    stringBuilder.Append(value.Slice(currentTokenStart, i - currentTokenStart));
                     stringBuilder.Append(closeBraceChar);
                     currentTokenStart = i;
                 }
             }
 
             // add the final section
-            stringBuilder.Append(value, currentTokenStart, (startIndex + count) - currentTokenStart);
+            stringBuilder.Append(value.Slice(currentTokenStart, (startIndex + count) - currentTokenStart));
         }
+        
+        
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Appends a Span to a StringBuilder.
+        ///
+        /// This is only needed in the netstandard2 implementation as under netstandard2.1
+        /// there is a native method for this.
+        /// </summary>
+        /// <param name="builder">The builder to which the result should be appended.</param>
+        /// <param name="value">The span to append</param>
+        public static void Append(this StringBuilder builder, ReadOnlySpan<char> value)
+        {
+            builder.Append(value.ToArray());
+        }
+#endif
     }
 }

--- a/FormatWith/Internal/Tokenizer.cs
+++ b/FormatWith/Internal/Tokenizer.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+
+namespace FormatWith.Internal
+{
+    // Can't use Action<FormatToken> as FormatToken is a ref struct
+    // which can't be used as a generic type parameter. 
+    internal delegate void SpanAction(FormatToken token);
+    
+    internal static class Tokenizer
+    {
+        /// <summary>
+        /// Tokenizes a named format string into a list of text and parameter tokens.
+        /// The supplied action is invoked for each token.
+        /// </summary>
+        /// <param name="formatString">The format string, containing keys like {foo}</param>
+        /// <param name="action">The callback to be invoked for each token.</param>
+        /// <param name="openBraceChar">The character used to begin parameters</param>
+        /// <param name="closeBraceChar">The character used to end parameters</param>
+        /// <returns>A list of text and parameter tokens representing the input format string</returns>
+        public static void Tokenize(ReadOnlySpan<char> formatString, SpanAction action, char openBraceChar = '{', char closeBraceChar = '}')
+        {
+            if (formatString == null) throw new ArgumentNullException($"{nameof(formatString)} cannot be null.");
+
+            int currentTokenStart = 0;
+
+            // start the state machine!
+
+            bool insideBraces = false;
+
+            int index = 0;
+            while (index < formatString.Length)
+            {
+                if (!insideBraces)
+                {
+                    // currently not inside a pair of braces in the format string
+                    if (formatString[index] == openBraceChar)
+                    {
+                        // check if the brace is escaped
+                        if (index < formatString.Length - 1 && formatString[index + 1] == openBraceChar)
+                        {
+                            // ESCAPED OPEN BRACE
+
+                            // we have hit an escaped open brace
+                            // return current normal text, as well as the first brace
+                            // implemented as yield return, this generates a IEnumerator state machine.
+                            action(new FormatToken(TokenType.Text, formatString, currentTokenStart, (index - currentTokenStart) + 1));
+
+                            // skip over braces
+                            index += 2;
+
+                            // set new current token start and current token length
+                            currentTokenStart = index;
+
+                            continue;
+                        }
+                        else
+                        {
+                            // START OF PARAMETER
+
+                            // not an escaped brace, set state to inside brace
+                            insideBraces = true;
+
+                            // we are leaving standard text and entering into a parameter
+                            // add the text traversed so far as a text token
+                            if (currentTokenStart < index)
+                            {
+                                action(new FormatToken(TokenType.Text, formatString, currentTokenStart, (index - currentTokenStart)));
+                            }
+
+                            // set the start index of the token to the start of this parameter
+                            currentTokenStart = index;
+
+                            index++;
+
+                            continue;
+                        }
+                    }
+                    else if (formatString[index] == closeBraceChar)
+                    {
+                        // handle case where closing brace is encountered outside braces
+                        if (index < formatString.Length - 1 && formatString[index + 1] == closeBraceChar)
+                        {
+                            // this is an escaped closing brace, this is okay
+
+                            // add the current normal text, as well as the first brace, to the
+                            // list of tokens as a text token.
+                            action(new FormatToken(TokenType.Text, formatString, currentTokenStart, (index - currentTokenStart) + 1));
+
+                            // skip over braces
+                            index += 2;
+
+                            // set new current token start and current token length
+                            currentTokenStart = index;
+
+                            continue;
+                        }
+                        else
+                        {
+                            // this is an unescaped closing brace outside of braces.
+                            // throw a format exception
+                            throw new FormatException($"Unexpected closing brace at position {index}");
+                        }
+                    }
+                    else
+                    {
+                        // move onto next character
+                        index++;
+                        continue;
+                    }
+                }
+                else
+                {
+                    // currently inside a pair of braces in the format string
+                    if (formatString[index] == openBraceChar)
+                    {
+                        // found an opening brace
+                        // check if the brace is escaped
+                        if (index < formatString.Length - 1 && formatString[index + 1] == openBraceChar)
+                        {
+                            // there are escaped braces within the key
+                            // this is illegal, throw a format exception
+                            throw new FormatException($"Illegal escaped opening braces within a parameter at position {index}");
+                        }
+                        else
+                        {
+                            // not an escaped brace, we have an unexpected opening brace within a pair of braces
+                            throw new FormatException($"Unexpected opening brace inside a parameter at position {index}");
+                        }
+                    }
+                    else if (formatString[index] == closeBraceChar)
+                    {
+                        // END OF PARAMETER
+                        // handle case where closing brace is encountered inside braces
+                        // don't attempt to check for escaped braces here - always assume the first brace closes the braces
+                        // since we cannot have escaped braces within parameters.
+
+                        // Add the parameter information to the parameter list
+                        action(new FormatToken(TokenType.Parameter, formatString, currentTokenStart, (index - currentTokenStart) + 1));
+
+                        // set the state to be outside of any braces
+                        insideBraces = false;
+
+                        // jump over brace
+                        index++;
+
+                        // update current token start
+                        currentTokenStart = index;
+
+                        // jump to next state
+                        continue;
+                    } // if }
+                    else
+                    {
+                        // character has no special meaning, it is part of the current key
+                        // move onto next character
+                        index++;
+                        continue;
+                    } // else
+                } // if inside brace
+            } // while index < formatString.Length
+
+            // after the loop, if all braces were balanced, we should be outside all braces
+            // if we're not, the input string was misformatted.
+            if (insideBraces)
+            {
+                throw new FormatException($"The format string ended before the parameter was closed. Position {index}");
+            }
+            else
+            {
+                // outside braces. Add on any remaining text at the end of the format string
+                if (currentTokenStart < index)
+                {
+                    action(new FormatToken(TokenType.Text, formatString, currentTokenStart, index - currentTokenStart));
+                }
+            }
+        }
+    }
+}

--- a/FormatWithTests/FormatWithTests.csproj
+++ b/FormatWithTests/FormatWithTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Hi @crozone 

This is an initial Span-based implementation of FormatWith (#8). Please feel free to use as much/little of it as you like (or discard completely if it doesn't fit with the way you want to do this!)

Here's a summary of what I've done:

# FormatToken struct
- FormatToken now becomes a `ref struct` so that it can now wrap a `ReadOnlySpan<char>` instead of a `string`. 
- The `SourceString`, `Raw` and `Value` properties now expose `ReadOnlySpan<char>` instead of `string`

# Tokenizer updates
- Moved Tokenizer to a separate file (just for my ease of working on it!)
- `Tokenizer.Tokenize` no longer returns an `IEnumerable<FormatToken>` (as ref structs can't be generic parameters), but returns void and accepts a delegate as its second parameter. This delegate is invoked for each token that's encountered.  

The method signature is now:

```csharp
public static void Tokenize(ReadOnlySpan<char> formatString, SpanAction action, char openBraceChar = '{', char closeBraceChar = '}')
```

...where `SpanAction` is defined as `internal delegate void SpanAction(FormatToken token)` (can't use `Action<FormatToken>` as ref structs can't be used as type parameters).

# ProcessTokens / ProcessTokensIntoFormattableString
- Renamed to `ProcessToken` and `ProcessTokenIntoFormattableString` (singular)
- Instead of accepting an `IEnumerable<FormatToken>`, these methods now accept just a single `FormatToken`
- These methods are passed in as the `action` callback when calling `Tokenize`

# Backwards compatibility with netstandard2 
For netstandard2.1, `Span` is native, as are methods such as `StringBuilder.Append(Span<char>)`. 

For netstandard2, the `System.Memory` package can be used to add Span support to older frameworks. This has the caveat that StringBuilder doesn't have an overload that accepts Span, but I hacked this in with an extension method with `#ifdefs`. 

The advantage of this approach is very little conditional compilation is necessary, as the API is globally working with spans. The downside is that using `Span` on older frameworks is probably actually going to be slower than your original implementation. This may be an acceptable tradeoff, or you might feel it's better to to stick with the old approach when running under netstandard2.0, and have more conditional compilation instead. Let me know what you think.

# Further work

There are a couple of areas that could be optimised further, but wanted to let you have a look before I do any more on this.

*Edit*: I also notice you don't have continuous integration set up on here. I'd be happy to do the work to add that in for you with github actions, if you'd like it. 
