### PR TITLE
Add continuous integration.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: ['windows-2019', 'ubuntu-20.04']
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        
+    - name: Build and Test
+      run: dotnet test -c release 
+      shell: pwsh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/FormatWith)](https://www.nuget.org/packages/FormatWith/)
 [![license](https://img.shields.io/github/license/crozone/FormatWith)](https://github.com/crozone/FormatWith/blob/master/License.txt)
+![Build status](https://github.com/crozone/FormatWith/workflows/CI/badge.svg)
 
 A set of string extension methods for performing {named} {{parameterized}} string formatting, written for NetStandard 2.0.
 


### PR DESCRIPTION
Adds continuous integration using github actions. 

On commits to master, or pull requests to master, a `dotnet test` will be run which will fail the build if compilation or tests fail. Builds are run on both Windows and Linux. For pull requests, the checks section at the bottom of the PR will indicate whether or not the build succeeded (as an example: https://github.com/FluentValidation/FluentValidation/pull/1474) 