### PR TITLE
Add string alignment handling to FormatWith functionality

### DIFF
--- a/FormatWith/Internal/FormatHelpers.cs
+++ b/FormatWith/Internal/FormatHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -43,39 +43,22 @@ namespace FormatWith.Internal
                 {
                     // token is a parameter token
                     // perform parameter logic now.
-                    var tokenKey = thisToken.Value;
-                    string format = null;
-                    var separatorIdx = tokenKey.IndexOf(":", StringComparison.Ordinal);
-                    if (separatorIdx > -1)
-                    {
-                        format = thisToken.Value.Substring(separatorIdx + 1);
-                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
-                    }
-                    /// Parse out alignment
-                    string alignment = null;
-                    var alignmentIdx = tokenKey.LastIndexOf(",", StringComparison.Ordinal);
-                    if(alignmentIdx > -1)
-                    {
-                        alignment = thisToken.Value.Substring(alignmentIdx + 1);
-                        tokenKey = thisToken.Value.Substring(0, alignmentIdx);
-                    }
-                    /// assemble full format string ([,ALIGNMENT][:FORMAT])
-                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty);
+                    TokenInformation tokenInfo = new TokenInformation(thisToken.Value);
 
                     // append the replacement for this parameter
-                    ReplacementResult replacementResult = handler(tokenKey, format);
-                
+                    ReplacementResult replacementResult = handler(tokenInfo.TokenKey, tokenInfo.Format);
+
                     if (replacementResult.Success)
                     {
                         // the key exists, add the replacement value
                         // this does nothing if replacement value is null
-                        if (string.IsNullOrWhiteSpace(formatString))
+                        if (string.IsNullOrWhiteSpace(tokenInfo.FormatString))
                         {
                             resultBuilder.Append(replacementResult.Value);
                         }
                         else
                         {
-                            resultBuilder.AppendFormat("{0" + formatString + "}", replacementResult.Value);
+                            resultBuilder.AppendFormat("{0" + tokenInfo.FormatString + "}", replacementResult.Value);
                         }
                     }
                     else
@@ -143,36 +126,19 @@ namespace FormatWith.Internal
                 {
                     // token is a parameter token
                     // perform parameter logic now.
-                    var tokenKey = thisToken.Value;
-                    string format = null;
-                    var separatorIdx = tokenKey.IndexOf(":", StringComparison.Ordinal);
-                    if (separatorIdx > -1)
-                    {
-                        format = thisToken.Value.Substring(separatorIdx + 1);
-                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
-                    }
-                    /// Parse out alignment
-                    string alignment = null;
-                    var alignmentIdx = tokenKey.LastIndexOf(",", StringComparison.Ordinal);
-                    If(alignmentIdx > -1)
-                    {
-                        alignment = thisToken.Value.Substring(alignmentIdx + 1);
-                        tokenKey = thisToken.Value.Substring(0, alignmentIdx);
-                    }
-                    /// assemble full format string ([,ALIGNMENT][:FORMAT])
-                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty);
+                    TokenInformation tokenInfo = new TokenInformation(thisToken.Value);
 
                     // append the replacement for this parameter
-                    ReplacementResult replacementResult = handler(tokenKey);
+                    ReplacementResult replacementResult = handler(tokenInfo.TokenKey);
 
                     string IndexAndFormat()
                     {
-                        if (string.IsNullOrWhiteSpace(formatString))
+                        if (string.IsNullOrWhiteSpace(tokenInfo.FormatString))
                         {
                             return "{" + placeholderIndex + "}";
                         }
 
-                        return "{" + placeholderIndex + formatString + "}";
+                        return "{" + placeholderIndex + tokenInfo.FormatString + "}";
                     }
 
                     // append the replacement for this parameter

--- a/FormatWith/Internal/FormatHelpers.cs
+++ b/FormatWith/Internal/FormatHelpers.cs
@@ -48,19 +48,19 @@ namespace FormatWith.Internal
                     var separatorIdx = tokenKey.IndexOf(":", StringComparison.Ordinal);
                     if (separatorIdx > -1)
                     {
-                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
                         format = thisToken.Value.Substring(separatorIdx + 1);
+                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
                     }
                     /// Parse out alignment
                     string alignment = null;
                     var alignmentIdx = tokenKey.LastIndexOf(",", StringComparison.Ordinal);
-                    If(alignmentIdx > -1)
+                    if(alignmentIdx > -1)
                     {
-                        tokeyKey = thisToken.Value.Substring(0, alignmentIdx);
                         alignment = thisToken.Value.Substring(alignmentIdx + 1);
+                        tokenKey = thisToken.Value.Substring(0, alignmentIdx);
                     }
                     /// assemble full format string ([,ALIGNMENT][:FORMAT])
-                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty)
+                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty);
 
                     // append the replacement for this parameter
                     ReplacementResult replacementResult = handler(tokenKey, format);

--- a/FormatWith/Internal/FormatHelpers.cs
+++ b/FormatWith/Internal/FormatHelpers.cs
@@ -51,6 +51,16 @@ namespace FormatWith.Internal
                         tokenKey = thisToken.Value.Substring(0, separatorIdx);
                         format = thisToken.Value.Substring(separatorIdx + 1);
                     }
+                    /// Parse out alignment
+                    string alignment = null;
+                    var alignmentIdx = tokenKey.LastIndexOf(",", StringComparison.Ordinal);
+                    If(alignmentIdx > -1)
+                    {
+                        tokeyKey = thisToken.Value.Substring(0, alignmentIdx);
+                        alignment = thisToken.Value.Substring(alignmentIdx + 1);
+                    }
+                    /// assemble full format string ([,ALIGNMENT][:FORMAT])
+                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty)
 
                     // append the replacement for this parameter
                     ReplacementResult replacementResult = handler(tokenKey, format);
@@ -65,7 +75,7 @@ namespace FormatWith.Internal
                         }
                         else
                         {
-                            resultBuilder.AppendFormat("{0:" + format + "}", replacementResult.Value);
+                            resultBuilder.AppendFormat("{0" + formatString + "}", replacementResult.Value);
                         }
                     }
                     else
@@ -141,6 +151,16 @@ namespace FormatWith.Internal
                         tokenKey = thisToken.Value.Substring(0, separatorIdx);
                         format = thisToken.Value.Substring(separatorIdx + 1);
                     }
+                    /// Parse out alignment
+                    string alignment = null;
+                    var alignmentIdx = tokenKey.LastIndexOf(",", StringComparison.Ordinal);
+                    If(alignmentIdx > -1)
+                    {
+                        tokeyKey = thisToken.Value.Substring(0, alignmentIdx);
+                        alignment = thisToken.Value.Substring(alignmentIdx + 1);
+                    }
+                    /// assemble full format string ([,ALIGNMENT][:FORMAT])
+                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty)
 
                     // append the replacement for this parameter
                     ReplacementResult replacementResult = handler(tokenKey);
@@ -152,7 +172,7 @@ namespace FormatWith.Internal
                             return "{" + placeholderIndex + "}";
                         }
 
-                        return "{" + placeholderIndex + ":" + format + "}";
+                        return "{" + placeholderIndex + formatString + "}";
                     }
 
                     // append the replacement for this parameter

--- a/FormatWith/Internal/FormatHelpers.cs
+++ b/FormatWith/Internal/FormatHelpers.cs
@@ -148,19 +148,19 @@ namespace FormatWith.Internal
                     var separatorIdx = tokenKey.IndexOf(":", StringComparison.Ordinal);
                     if (separatorIdx > -1)
                     {
-                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
                         format = thisToken.Value.Substring(separatorIdx + 1);
+                        tokenKey = thisToken.Value.Substring(0, separatorIdx);
                     }
                     /// Parse out alignment
                     string alignment = null;
                     var alignmentIdx = tokenKey.LastIndexOf(",", StringComparison.Ordinal);
                     If(alignmentIdx > -1)
                     {
-                        tokeyKey = thisToken.Value.Substring(0, alignmentIdx);
                         alignment = thisToken.Value.Substring(alignmentIdx + 1);
+                        tokenKey = thisToken.Value.Substring(0, alignmentIdx);
                     }
                     /// assemble full format string ([,ALIGNMENT][:FORMAT])
-                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty)
+                    string formatString = ((alignmentIdx > -1) ? $",{alignment}" : System.String.Empty) + ((separatorIdx > -1) ? $":{format}" : System.String.Empty);
 
                     // append the replacement for this parameter
                     ReplacementResult replacementResult = handler(tokenKey);

--- a/FormatWith/Internal/FormatHelpers.cs
+++ b/FormatWith/Internal/FormatHelpers.cs
@@ -69,7 +69,7 @@ namespace FormatWith.Internal
                     {
                         // the key exists, add the replacement value
                         // this does nothing if replacement value is null
-                        if (string.IsNullOrWhiteSpace(format))
+                        if (string.IsNullOrWhiteSpace(formatString))
                         {
                             resultBuilder.Append(replacementResult.Value);
                         }
@@ -167,7 +167,7 @@ namespace FormatWith.Internal
 
                     string IndexAndFormat()
                     {
-                        if (string.IsNullOrWhiteSpace(format))
+                        if (string.IsNullOrWhiteSpace(formatString))
                         {
                             return "{" + placeholderIndex + "}";
                         }

--- a/FormatWith/TokenInformation.cs
+++ b/FormatWith/TokenInformation.cs
@@ -1,0 +1,192 @@
+namespace FormatWith
+{
+
+    /// <summary>
+    /// Encapsulates the token-parsing logic and values, ensuring consistent behavior and allowing them to be passed to handlers more concisely.
+    /// </summary>
+    public class TokenInformation
+    {
+
+        #region Static & Const
+
+        ///// <summary>
+        ///// A regular expression to parse the token
+        ///// </summary>
+        //private static readonly System.Text.RegularExpressions.Regex _parseRegEx = new System.Text.RegularExpressions.Regex(@"(?<token>([^,;:\s]+))(,(?<alignment>-?\d+))?(:(?<format>.*))?", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The raw token parsed.
+        /// </summary>
+        public string RawToken { get; private set; }
+
+        /// <summary>
+        /// The token key.
+        /// </summary>
+        public string TokenKey { get; private set; }
+
+        /// <summary>
+        /// The alignment indicator
+        /// </summary>
+        public string Alignment { get; private set; }
+
+        /// <summary>
+        /// The base format string. (no alignment)
+        /// </summary>
+        public string Format { get; private set; }
+
+        private string _formatString = null;
+        /// <summary>
+        /// The full composite formatting string. [,align][:format]
+        /// </summary>
+        public string FormatString
+        {
+            get
+            {
+                if (null == this._formatString)
+                {
+                    this._formatString = string.Concat((!string.IsNullOrEmpty(this.Alignment) ? $",{this.Alignment}" : string.Empty), (!string.IsNullOrEmpty(this.Format) ? $":{this.Format}" : string.Empty));
+                }
+                return (this._formatString);
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Parses token information from a raw token string value.
+        /// </summary>
+        /// <param name="rawToken">The raw token string.</param>
+        /// <remarks>IndexOf/Substring version of parser based on existing code</remarks>
+        public TokenInformation(string rawToken)
+        {
+            this.RawToken = rawToken;
+            this.Format = null;
+            this.Alignment = null;
+
+            // Parse out the format
+            var separatorIdx = rawToken.IndexOf(":", System.StringComparison.Ordinal);
+            if (separatorIdx > -1)
+            {
+                this.Format = rawToken.Substring(separatorIdx + 1);
+                rawToken = rawToken.Substring(0, separatorIdx);
+            }
+
+            // Parse out alignment
+            var alignmentIdx = rawToken.LastIndexOf(",", System.StringComparison.Ordinal);
+            if (alignmentIdx > -1)
+            {
+                this.Alignment = rawToken.Substring(alignmentIdx + 1);
+                rawToken = rawToken.Substring(0, alignmentIdx);
+            }
+
+            // Grab the token key
+            this.TokenKey = rawToken;
+        }
+
+        ///// <summary>
+        ///// Parses token information from a raw token string value.
+        ///// </summary>
+        ///// <param name="rawToken">The raw token string.</param>
+        ///// <remarks>RegEx version of parser, for performance comparison, and in case someone else knows how to optimize it more</remarks>
+        //public TokenInformation(string rawToken, bool ignoreThisParameterItIsHereForPerformanceComparisons)
+        //{
+        //	this.RawToken = rawToken;
+        //	this.Alignment = null;
+        //	this.Format = null;
+        //	
+        //	System.Text.RegularExpressions.Match results = _parseRegEx.Match(rawToken);
+        //	if(results.Success)
+        //	{
+        //		this.TokenKey = results.Groups["token"].Value;
+        //		this.Alignment = results.Groups["alignment"].Value;
+        //		this.Format = results.Groups["format"].Value;
+        //	}
+        //}
+
+        #endregion
+
+        #region Methods
+
+        private static string BuildString(string tokenKey, string alignment, string format)
+        {
+            string rawToken = string.Concat(tokenKey, (!string.IsNullOrEmpty(alignment) ? $",{alignment}" : string.Empty), (!string.IsNullOrEmpty(format) ? $":{format}" : string.Empty));
+            return (rawToken);
+        }
+
+        /// <summary>
+        /// Builds a raw token string given the desired tokenKey and format
+        /// </summary>
+        /// <param name="tokenKey">The key value for the token.</param>
+        /// <param name="alignment">The left- or right-padding indicator desired.</param>
+        /// <param name="format">The format string.</param>
+        /// <returns></returns>
+        public static string BuildString(string tokenKey, int? alignment, string format)
+        {
+            return (TokenInformation.BuildString(tokenKey, alignment.HasValue ? $"{alignment}" : string.Empty, format));
+        }
+
+        /// <summary>
+        /// Builds a raw token string given the desired tokenKey and format
+        /// </summary>
+        /// <param name="tokenKey">The key value for the token.</param>
+        /// <param name="format">The format string.</param>
+        /// <returns></returns>
+        public static string BuildString(string tokenKey, string format)
+        {
+            return (TokenInformation.BuildString(tokenKey, (int?)null, format));
+        }
+
+        /// <summary>
+        /// Builds a raw token string given the desired tokenKey and format
+        /// </summary>
+        /// <param name="tokenKey">The key value for the token.</param>
+        /// <param name="alignment">The left- or right-padding indicator desired.</param>
+        /// <returns></returns>
+        public static string BuildString(string tokenKey, int? alignment)
+        {
+            return (TokenInformation.BuildString(tokenKey, alignment, null));
+        }
+
+        /// <summary>
+        /// Builds a raw token string given the desired tokenKey and format
+        /// </summary>
+        /// <param name="tokenKey">The key value for the token.</param>
+        /// <returns></returns>
+        public static string BuildString(string tokenKey)
+        {
+            return(TokenInformation.BuildString(tokenKey, (int?)null, null));
+        }
+
+        /// <summary>
+        /// Builds a TokenInfo object given the desired tokenKey and format
+        /// </summary>
+        /// <param name="tokenKey">The key value for the token.</param>
+        /// <param name="alignment">The left- or right-padding indicator desired.</param>
+        /// <param name="format">The format string.</param>
+        /// <returns></returns>
+        public static TokenInformation Build(string tokenKey, int? alignment, string format)
+        {
+            return (new TokenInformation(TokenInformation.BuildString(tokenKey, alignment, format)));
+        }
+
+        /// <summary>
+        /// Builds a TokenInfo object given the desired tokenKey and format
+        /// </summary>
+        /// <param name="tokenKey">The key value for the token.</param>
+        /// <param name="format">The format string.</param>
+        /// <returns></returns>
+        public static TokenInformation Build(string tokenKey, string format)
+        {
+            return (TokenInformation.Build(tokenKey, null, format));
+        }
+
+        #endregion
+
+    }   // end class
+}   // end namespace

--- a/FormatWithTests/FormatWithTests.cs
+++ b/FormatWithTests/FormatWithTests.cs
@@ -171,18 +171,6 @@ namespace FormatWithTests
         }
 
         [Fact]
-        public void LeftPadTest()
-        {
-            Dictionary<string, object> replacementDictionary = new Dictionary<string, object>()
-            {
-                ["LeftPadTestValue"] = LeftPadTestValue
-            };
-            System.String expectedValue = "'       1,234.56'";
-            Assert.Equal(System.String.Format(LeftPadTestFormatComposite, LeftPadTestValue), exectedValue);
-            Assert.Equal(LeftPadTestValue.FormatWith(replacementDictionary), expectedValue);
-        }
-        
-        [Fact]
         public void SpeedTest()
         {
             Dictionary<string, string> replacementDictionary = new Dictionary<string, string>()

--- a/FormatWithTests/FormatWithTests.cs
+++ b/FormatWithTests/FormatWithTests.cs
@@ -171,6 +171,18 @@ namespace FormatWithTests
         }
 
         [Fact]
+        public void LeftPadTest()
+        {
+            Dictionary<string, object> replacementDictionary = new Dictionary<string, object>()
+            {
+                ["LeftPadTestValue"] = LeftPadTestValue
+            };
+            System.String expectedValue = "'       1,234.56'";
+            Assert.Equal(System.String.Format(LeftPadTestFormatComposite, LeftPadTestValue), exectedValue);
+            Assert.Equal(LeftPadTestValue.FormatWith(replacementDictionary), expectedValue);
+        }
+        
+        [Fact]
         public void SpeedTest()
         {
             Dictionary<string, string> replacementDictionary = new Dictionary<string, string>()

--- a/FormatWithTests/TestStrings.cs
+++ b/FormatWithTests/TestStrings.cs
@@ -33,9 +33,5 @@ namespace FormatWithTests
         public static readonly string TestFormat7Composite = "Today is {0:YYYYMMDD HH:mm}";
         public static readonly DateTime TestFormat7Date = new DateTime(2018, 10, 30, 17, 25, 0);
         public static readonly string TestFormat7Solution = $"Today is {TestFormat7Date:YYYYMMDD HH:mm}";
-
-        public static readonly Decimal LeftPadTestValue = 1234.56;
-        public static readonly string LeftPadTestFormat = "'{LeftPadTestValue,15:#,##.00}'";
-        public static readonly string LeftPadTestFormatComposite = "'{0,15:#,##.00}'";
     }
 }

--- a/FormatWithTests/TestStrings.cs
+++ b/FormatWithTests/TestStrings.cs
@@ -28,10 +28,14 @@ namespace FormatWithTests
         public static readonly string TestFormat6 = "abc{Replacement1:upper}";
         public static readonly string TestFormat6Composite = "abc{0:upper}";
         public static readonly string TestFormat6Solution = $"abc{Replacement1.ToUpper()}";
-        
+
         public static readonly string TestFormat7 = "Today is {Today:YYYYMMDD HH:mm}";
         public static readonly string TestFormat7Composite = "Today is {0:YYYYMMDD HH:mm}";
         public static readonly DateTime TestFormat7Date = new DateTime(2018, 10, 30, 17, 25, 0);
         public static readonly string TestFormat7Solution = $"Today is {TestFormat7Date:YYYYMMDD HH:mm}";
+
+        public static readonly Decimal LeftPadTestValue = 1234.56;
+        public static readonly string LeftPadTestFormat = "'{LeftPadTestValue,15:#,##.00}'";
+        public static readonly string LeftPadTestFormatComposite = "'{0,15:#,##.00}'";
     }
 }

--- a/FormatWithTests/TokenInformationTests.cs
+++ b/FormatWithTests/TokenInformationTests.cs
@@ -118,5 +118,45 @@ namespace FormatWithTests
 
         #endregion
 
+        #region FormatWith
+
+        [Fact]
+        public void FormatWith_DateTest_FormatOnly()
+        {
+            System.Collections.Generic.Dictionary<string, object> replacmentValues = new System.Collections.Generic.Dictionary<string, object>();
+            replacmentValues.Add(testTokenKey, testDate);
+
+            string expectedResult = "'2024-08-29'";
+            string result = "'{token:yyyy-MM-dd}'".FormatWith(replacmentValues);
+
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Fact]
+        public void FormatWith_DateTest_FormatAndLeftPad()
+        {
+            System.Collections.Generic.Dictionary<string, object> replacmentValues = new System.Collections.Generic.Dictionary<string, object>();
+            replacmentValues.Add(testTokenKey, testDate);
+
+            string expectedResult = "'     2024-08-29'";
+            string result = "'{token,15:yyyy-MM-dd}'".FormatWith(replacmentValues);
+
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Fact]
+        public void FormatWith_DateTest_FormatAndRightPad()
+        {
+            System.Collections.Generic.Dictionary<string, object> replacmentValues = new System.Collections.Generic.Dictionary<string, object>();
+            replacmentValues.Add(testTokenKey, testDate);
+
+            string expectedResult = "'2024-08-29     '";
+            string result = "'{token,-15:yyyy-MM-dd}'".FormatWith(replacmentValues);
+
+            Assert.Equal(result, expectedResult);
+        }
+
+        #endregion
+
     }   // end class
 }   // end namespace

--- a/FormatWithTests/TokenInformationTests.cs
+++ b/FormatWithTests/TokenInformationTests.cs
@@ -1,0 +1,122 @@
+using Xunit;
+using FormatWith;
+using Xunit.Sdk;
+
+namespace FormatWithTests
+{
+    public class TokenInformationTests
+    {
+
+        #region Test Values
+
+        private static string testTokenKey = "token";
+        private static int? testLeftPad = 15;
+        private static int? testRightPad = -15;
+        private static string testFormat = "yyyy-MM-dd";
+        private static System.DateTime testDate = new System.DateTime(2024, 8, 29);
+
+        public class Parse_TestData : TheoryData<string, string, int?, string>
+        {
+            public Parse_TestData()
+            {
+            }
+        };
+
+        #endregion
+
+        #region BuildString
+
+        [Fact]
+        public void BuildString_TokenOnly()
+        {
+            string expected = "token";
+
+            string result = TokenInformation.BuildString(testTokenKey);
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void BuildString_TokenAndLeftPad()
+        {
+            string expected = "token,15";
+
+            string result = TokenInformation.BuildString(testTokenKey, testLeftPad);
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void BuildString_TokenAndRightPad()
+        {
+            string expected = "token,-15";
+
+            string result = TokenInformation.BuildString(testTokenKey, testRightPad);
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void BuildString_TokenAndFormat()
+        {
+            string expected = "token:yyyy-MM-dd";
+
+            string result = TokenInformation.BuildString(testTokenKey, testFormat);
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void BuildString_TokenLeftPadAndFormat()
+        {
+            string expected = "token,15:yyyy-MM-dd";
+
+            string result = TokenInformation.BuildString(testTokenKey, testLeftPad, testFormat);
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void BuildString_TokenAndRightPadAndFormat()
+        {
+            string expected = "token,-15:yyyy-MM-dd";
+
+            string result = TokenInformation.BuildString(testTokenKey, testRightPad, testFormat);
+            Assert.Equal(result, expected);
+        }
+
+        #endregion
+
+        #region Parse
+
+        [Theory]
+        [InlineData("token", "token", null, null, "")]
+        [InlineData("token,15", "token", "15", null, ",15")]
+        [InlineData("token,-15", "token", "-15", null, ",-15")]
+        [InlineData("token:yyyy-MM-dd", "token", null, "yyyy-MM-dd", ":yyyy-MM-dd")]
+        [InlineData("token,15:yyyy-MM-dd", "token", "15", "yyyy-MM-dd", ",15:yyyy-MM-dd")]
+        [InlineData("token,-15:yyyy-MM-dd", "token", "-15", "yyyy-MM-dd", ",-15:yyyy-MM-dd")]
+        public void Parse(string rawToken, string expectedTokenKey, string expectedAlignment, string expectedFormat, string expectedFormatString)
+        {
+            TokenInformation result = new TokenInformation(rawToken);
+
+            Assert.Equal(result.RawToken, rawToken);
+            Assert.Equal(result.TokenKey, expectedTokenKey);
+            if (null == expectedAlignment)
+            {
+                Assert.Null(result.Alignment);
+            }
+            else
+            {
+                Assert.Equal(result.Alignment, expectedAlignment);
+            }
+            if (null == expectedFormat)
+            {
+                Assert.Null(result.Format);
+            }
+            else
+            {
+                Assert.Equal(result.Format, expectedFormat);
+            }
+            Assert.Equal(result.FormatString, expectedFormatString);
+        }
+
+        #endregion
+
+    }   // end class
+}   // end namespace


### PR DESCRIPTION
Additional values & tests for a left-padding format string.

This type of format string does not currently work in FormatWith.
I suspect a format-string parse issue, where it assumes the first format-string delimiter is ':', rather than a potential ','.
I've been trying to find workarounds, but haven't managed to do so yet.